### PR TITLE
made mpad.js url distributor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ The authorization flow depends on the `mpad.js` browser library. To show the log
 (authorization URL) and `data-element` (login button ID)
 
 ```
-<script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+<script src="<<Insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
 ```
+
+Please refer to your distributor-specific documentation to find the correct url for the mpad.js `script src`
 
 ### MiraclMixin
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -76,8 +76,9 @@
         </div>
     {% end %}
     </div>
+    <!--Please refer to your distributor-specific documentation to find the correct url for the mpad.js script src-->
     {% if retry or not is_authorized %}
-        <script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+        <script src="<<insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
     {% end %}
 </body>
 </html>


### PR DESCRIPTION
This to make the SDK repos distributor-neutral.

The instructions for the correct mpad.js url are found in the devdocs for each distributor.